### PR TITLE
Optimisation of minimax algorithm

### DIFF
--- a/tic-tac-toe/project.clj
+++ b/tic-tac-toe/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/gemcfadyen/Apprenticeship-ClojureTicTacToe"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-RC2"]]
-  :profiles {:dev {:dependencies [[speclj "3.3.1"][clj-time "0.11.0"]]}}
+  :dependencies [[org.clojure/clojure "1.7.0-RC2"][clj-time "0.11.0"]]
+  :profiles {:dev {:dependencies [[speclj "3.3.1"]]}}
   :plugins [[speclj "3.3.1"]]
   :main ^:skip-aot tic-tac-toe.game
   :test-paths ["spec"])

--- a/tic-tac-toe/project.clj
+++ b/tic-tac-toe/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-RC2"]]
-  :profiles {:dev {:dependencies [[speclj "3.3.1"]]}}
+  :profiles {:dev {:dependencies [[speclj "3.3.1"][clj-time "0.11.0"]]}}
   :plugins [[speclj "3.3.1"]]
   :main ^:skip-aot tic-tac-toe.game
   :test-paths ["spec"])

--- a/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
@@ -1,7 +1,9 @@
 (ns tic-tac-toe.minimax-player-spec
   (:require [speclj.core :refer :all]
             [tic-tac-toe.minimax-player :refer :all]
-            [tic-tac-toe.marks :refer :all]))
+            [tic-tac-toe.marks :refer :all]
+            [tic-tac-toe.board :as board]
+            [clj-time.core :as t]))
 
 (def win-board [X O nil X O nil X nil nil])
 (def draw-board [O X O X O O X O X])
@@ -50,7 +52,7 @@
 
           (it "blocks opponent on bottom row"
               (should= 7
-              (choose-move [nil nil X nil X nil O nil O])))
+                       (choose-move [nil nil X nil X nil O nil O])))
 
           (it "blocks opponent on left column"
               (should= 3
@@ -76,6 +78,14 @@
           (should= 4
                    (choose-move [X nil nil nil nil nil nil nil nil])))
 
-         (it "should not allow a fork to form"
+         (it "does not allow a fork to form"
             (should= 1
-                     (choose-move [X nil nil nil O nil nil nil X]))))
+                     (choose-move [X nil nil nil O nil nil nil X])))
+
+          (it "takes first move in under one second"
+              (let  [starting-time (t/now)]
+                (choose-move (board/create-empty-board))
+                (let [finish-time (t/now)
+                      time-taken (t/in-seconds (t/interval starting-time finish-time))]
+                (should= true
+                          (< time-taken 1 ) )))) )

--- a/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
@@ -86,6 +86,7 @@
               (let  [starting-time (t/now)]
                 (choose-move (board/create-empty-board))
                 (let [finish-time (t/now)
-                      time-taken (t/in-seconds (t/interval starting-time finish-time))]
-                (should= true
-                          (< time-taken 1 ) )))) )
+                      time-taken (t/in-millis (t/interval starting-time finish-time))]
+                  (println "time taken " time-taken)
+                  (should= true
+                           (< time-taken 1000 ) )))) )

--- a/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
@@ -3,10 +3,13 @@
             [tic-tac-toe.minimax-player :refer :all]
             [tic-tac-toe.marks :refer :all]
             [tic-tac-toe.board :as board]
-            [clj-time.core :as t]))
+            [clj-time.core :as date-time]))
 
 (def win-board [X O nil X O nil X nil nil])
 (def draw-board [O X O X O O X O X])
+
+(defn- time-taken [starting-time finish-time]
+  (date-time/in-millis (date-time/interval starting-time finish-time)))
 
 (describe "Minimax Player"
 
@@ -83,10 +86,8 @@
                      (choose-move [X nil nil nil O nil nil nil X])))
 
           (it "takes first move in under one second"
-              (let  [starting-time (t/now)]
+              (let [starting-time (date-time/now)]
                 (choose-move (board/create-empty-board))
-                (let [finish-time (t/now)
-                      time-taken (t/in-millis (t/interval starting-time finish-time))]
-                  (println "time taken " time-taken)
+                (let [finish-time (date-time/now)]
                   (should= true
-                           (< time-taken 1000 ) )))) )
+                           (< (time-taken starting-time finish-time) 1000 ) )))))

--- a/tic-tac-toe/src/tic_tac_toe/board.clj
+++ b/tic-tac-toe/src/tic_tac_toe/board.clj
@@ -63,9 +63,7 @@
   (cond
     (memoized-winning-row? (get-rows board)) (memoized-find-winning-symbol (get-rows board))
     (memoized-winning-row? (get-columns board)) (memoized-find-winning-symbol (get-columns board))
-    (memoized-winning-row? (get-diagonals board)) (memoized-find-winning-symbol (get-diagonals board))
-    )
-  )
+    (memoized-winning-row? (get-diagonals board)) (memoized-find-winning-symbol (get-diagonals board))))
 
 (def winning-symbol (memoize cached-winning-symbol))
 

--- a/tic-tac-toe/src/tic_tac_toe/board.clj
+++ b/tic-tac-toe/src/tic_tac_toe/board.clj
@@ -9,10 +9,14 @@
 (defn- winning-row? [rows]
   (some true? (map three-matching-player-symbols? rows)))
 
+(def memoized-winning-row? (memoize winning-row?))
+
 (defn- find-winning-symbol [rows]
   (first
     (remove nil?
             (map (fn[row] (if (three-matching-player-symbols? row) (first row) nil)) rows))))
+
+(def memoized-find-winning-symbol (memoize find-winning-symbol))
 
 (defn create-empty-board []
   (vec (repeat 9 nil)))
@@ -47,21 +51,23 @@
    ]
   )
 
-(defn winning-line? [board]
+(defn cached-winning-line? [board]
   (boolean (or
-             (winning-row? (get-rows board))
-             (winning-row? (get-columns board))
-             (winning-row? (get-diagonals board))
-             ))
-  )
+             (memoized-winning-row? (get-rows board))
+             (memoized-winning-row? (get-columns board))
+             (memoized-winning-row? (get-diagonals board)))))
 
-(defn winning-symbol [board]
+(def winning-line? (memoize cached-winning-line?))
+
+(defn cached-winning-symbol [board]
   (cond
-    (winning-row? (get-rows board)) (find-winning-symbol (get-rows board))
-    (winning-row? (get-columns board)) (find-winning-symbol (get-columns board))
-    (winning-row? (get-diagonals board)) (find-winning-symbol (get-diagonals board))
+    (memoized-winning-row? (get-rows board)) (memoized-find-winning-symbol (get-rows board))
+    (memoized-winning-row? (get-columns board)) (memoized-find-winning-symbol (get-columns board))
+    (memoized-winning-row? (get-diagonals board)) (memoized-find-winning-symbol (get-diagonals board))
     )
   )
+
+(def winning-symbol (memoize cached-winning-symbol))
 
 (defn free-spaces? [board]
   (boolean (some nil? board)))

--- a/tic-tac-toe/src/tic_tac_toe/board.clj
+++ b/tic-tac-toe/src/tic_tac_toe/board.clj
@@ -6,17 +6,17 @@
   (let [[one two three] row]
     (and (= one two three) (not(= one nil)))))
 
-(defn- winning-row? [rows]
+(defn- has-winning-row? [rows]
   (some true? (map three-matching-player-symbols? rows)))
 
-(def memoized-winning-row? (memoize winning-row?))
+(def winning-row? (memoize has-winning-row?))
 
-(defn- find-winning-symbol [rows]
+(defn- get-winning-symbol [rows]
   (first
     (remove nil?
             (map (fn[row] (if (three-matching-player-symbols? row) (first row) nil)) rows))))
 
-(def memoized-find-winning-symbol (memoize find-winning-symbol))
+(def find-winning-symbol (memoize get-winning-symbol))
 
 (defn create-empty-board []
   (vec (repeat 9 nil)))
@@ -51,21 +51,21 @@
    ]
   )
 
-(defn cached-winning-line? [board]
+(defn has-winning-line? [board]
   (boolean (or
-             (memoized-winning-row? (get-rows board))
-             (memoized-winning-row? (get-columns board))
-             (memoized-winning-row? (get-diagonals board)))))
+             (winning-row? (get-rows board))
+             (winning-row? (get-columns board))
+             (winning-row? (get-diagonals board)))))
 
-(def winning-line? (memoize cached-winning-line?))
+(def winning-line? (memoize has-winning-line?))
 
-(defn cached-winning-symbol [board]
+(defn get-winning-symbol [board]
   (cond
-    (memoized-winning-row? (get-rows board)) (memoized-find-winning-symbol (get-rows board))
-    (memoized-winning-row? (get-columns board)) (memoized-find-winning-symbol (get-columns board))
-    (memoized-winning-row? (get-diagonals board)) (memoized-find-winning-symbol (get-diagonals board))))
+    (winning-row? (get-rows board)) (find-winning-symbol (get-rows board))
+    (winning-row? (get-columns board)) (find-winning-symbol (get-columns board))
+    (winning-row? (get-diagonals board)) (find-winning-symbol (get-diagonals board))))
 
-(def winning-symbol (memoize cached-winning-symbol))
+(def winning-symbol (memoize get-winning-symbol))
 
 (defn free-spaces? [board]
   (boolean (some nil? board)))

--- a/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
@@ -9,6 +9,8 @@
 (def initial-max-score -100)
 (def initial-min-score 100)
 (def position-placeholder -1)
+(def initial-alpha -100)
+(def initial-beta 100)
 
 (defn- calculate-initial-score [is-max-player]
   (if is-max-player
@@ -53,7 +55,20 @@
 (defn- no-free-spaces [remaining-spaces]
   (= 0 (count remaining-spaces)))
 
-(defn minimax [board depth is-max-player max-player-symbol]
+(defn- recalculate-alpha [is-max-player best-score alpha]
+  (if is-max-player
+    (max (second best-score) alpha)
+    alpha))
+
+(defn- recalculate-beta [is-max-player best-score beta]
+  (if is-max-player
+    beta
+    (min (second best-score) beta)))
+
+(defn- prune? [alpha beta]
+  (>= alpha beta))
+
+(defn minimax [board depth is-max-player max-player-symbol alpha beta]
   (let [initial-score (calculate-initial-score is-max-player)]
 
     (if (game-over? depth board)
@@ -61,19 +76,27 @@
       (do
 
         (loop [[first-free-slot & rest] (board/indicies-of-free-spaces board)
-               best-position initial-score]
+               best-position initial-score
+               alpha alpha
+               beta beta]
 
           (let [updated-board (board/place-mark board (marks/next-mark board) first-free-slot)
                 position (minimax
                            updated-board
                            (dec depth)
                            (not is-max-player)
-                           max-player-symbol)]
+                           max-player-symbol
+                           alpha
+                           beta)]
 
-            (let [latest-best-score (get-players-best-position is-max-player best-position position first-free-slot)]
-              (if (no-free-spaces rest)
-                latest-best-score
-                (recur rest latest-best-score)))))))))
+            (let [latest-best-score (get-players-best-position is-max-player best-position position first-free-slot)
+                  new-alpha (recalculate-alpha is-max-player latest-best-score alpha)
+                  new-beta (recalculate-beta is-max-player latest-best-score beta)]
+              (cond
+                (prune? new-alpha new-beta) latest-best-score
+                (no-free-spaces rest) latest-best-score
+                :else
+                (recur rest latest-best-score new-alpha new-beta)))))))))
 
 (defn choose-move [board]
   (let [is-max-player true
@@ -82,5 +105,7 @@
                                      board
                                      (count (board/indicies-of-free-spaces board))
                                      is-max-player
-                                     max-player-symbol)]
+                                     max-player-symbol
+                                     initial-alpha
+                                     initial-beta)]
     best-position))

--- a/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
@@ -68,13 +68,17 @@
 (defn- prune? [alpha beta]
   (>= alpha beta))
 
+(defn- stop-exploration-of-branches? [remaining-spaces alpha beta]
+  (or
+    (prune? alpha beta)
+    (no-free-spaces remaining-spaces)))
+
 (defn minimax [board depth is-max-player max-player-symbol alpha beta]
   (let [initial-score (calculate-initial-score is-max-player)]
 
     (if (game-over? depth board)
       (calculate-game-over-score board max-player-symbol depth)
       (do
-
         (loop [[first-free-slot & rest] (board/indicies-of-free-spaces board)
                best-position initial-score
                alpha alpha
@@ -92,10 +96,8 @@
             (let [latest-best-score (get-players-best-position is-max-player best-position position first-free-slot)
                   new-alpha (recalculate-alpha is-max-player latest-best-score alpha)
                   new-beta (recalculate-beta is-max-player latest-best-score beta)]
-              (cond
-                (prune? new-alpha new-beta) latest-best-score
-                (no-free-spaces rest) latest-best-score
-                :else
+              (if (stop-exploration-of-branches? rest new-alpha new-beta)
+                latest-best-score
                 (recur rest latest-best-score new-alpha new-beta)))))))))
 
 (defn choose-move [board]


### PR DESCRIPTION
@jsuchy @ecomba
This pull request speeds up the time taken for the minimax player taking the opening move.

It:
- Adds test to minimax player to ensure that minimax does not fall for a fork.
- Adds test to ensure the first move on an empty board for the minimax player can be taken in under one second.
  -- The time taken for the first minimax move, with no optimisation was: 25.94 seconds.
  -- When alpha beta pruning was added, this time was reduced down to 1.26 seconds.
  -- To decrease the time further, I memoized the methods which checks for winnings rows, and finds the winning symbols in the board module. This brought the time down to 0.24 milliseconds.
