### PR TITLE
Better ux for computer vs computer

### DIFF
--- a/tic-tac-toe/spec/tic_tac_toe/delayed_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/delayed_player_spec.clj
@@ -1,0 +1,24 @@
+(ns tic-tac-toe.random-player-spec
+  (:require [speclj.core :refer :all]
+            [tic-tac-toe.random-player :refer :all]
+            [tic-tac-toe.marks :refer :all]
+            [tic-tac-toe.board :as board]
+            [tic-tac-toe.delayed-player :as delayed-player]))
+
+(def fake-player 2)
+
+(defn prove-execution[msg]
+  (print "Has executed from" msg))
+
+(describe "Delayed Player"
+
+          (it "Executes another function when making a delayed move"
+              (binding [delayed-player/sleep prove-execution]
+                (should= "Has executed from delayed-move test"
+                         (with-out-str
+                           (delayed-move "delayed-move test" fake-player [X O X X X O O nil O])))))
+
+          (it "Provides next move"
+              (binding [delayed-player/sleep (fn [nothing-happens] nothing-happens)]
+                (should= 2
+                         (delayed-move "delayed-move test" fake-player [X O X X X O O nil O])))))

--- a/tic-tac-toe/spec/tic_tac_toe/game_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/game_spec.clj
@@ -20,32 +20,40 @@
 
 (describe "Tic Tac Toe"
           (with-stubs)
-          (around [it]
-                  (with-out-str (it)))
+                    (around [it]
+                            (with-out-str (it)))
 
           (it "game is setup for moves to be made"
-              (with-redefs [prompt/get-replay-option (stub :replay {:return "No replay"})
-                            get-players (stub :get-players {:return fake-players})
-                            board/create-empty-board (stub :create-new-board {:return (empty-board)})
-                            play-move (stub :play-move {:return "moves are made"})]
+               (with-redefs [prompt/get-replay-option (stub :replay {:return "No replay"})
+                             get-players (stub :get-players {:return fake-players})
+                             board/create-empty-board (stub :create-new-board {:return (empty-board)})
+                             play-move (stub :play-move {:return "moves are made"})]
 
-                (play-game)
+                 (play-game)
 
-                (should-have-invoked :create-new-board {:times 1})
-                (should-have-invoked :get-players {:times 1})
-                (should-have-invoked :play-move {:times 1})))
+                 (should-have-invoked :create-new-board {:times 1})
+                 (should-have-invoked :get-players {:times 1})
+                 (should-have-invoked :play-move {:times 1})))
 
           (it "game ends with goodbye message"
-              (with-redefs [play-game (stub :play-game {:return "game is played"})
-                            writer/goodbye-msg (stub :goodbye ) ]
-                (start)
+               (with-redefs [play-game (stub :play-game {:return "game is played"})
+                             writer/goodbye-msg (stub :goodbye ) ]
+                 (start)
 
-                (should-have-invoked :play-game {:times 1})
-                (should-have-invoked :goodbye {:times 1})))
+                 (should-have-invoked :play-game {:times 1})
+                 (should-have-invoked :goodbye {:times 1})))
 
           (it "players move updates the board"
               (should= [O nil X nil O X nil nil X]
                        (update-board-with-move fake-players [O nil nil nil O X nil nil X] X)))
+
+          (it "displays board with each move taken and when game is over"
+              (with-redefs [writer/display (stub :display {:return "Board is displayed"})
+                            prompt/get-replay-option (stub :no-replay {:return "N"})]
+                (with-in-str "2\n8\n"
+                  (play-move [X nil X O X X O nil O]
+                             (players/configure-players player-options/human-human-id))
+                  (should-have-invoked :display {:times 3}))))
 
           (it "displays board when game is won"
               (with-redefs [writer/display (stub :display {:return "Board is displayed"})]
@@ -64,47 +72,47 @@
                   (play-move [X O nil nil X O O X nil]
                              (players/configure-players player-options/human-human-id ))
 
-                  (should-have-invoked :winning-line? {:times 4})))
+                  (should-have-invoked :winning-line? {:times 4}))))
 
-              (it "checks for a draw after each move until a win takes place"
-                  (with-redefs [no-free-spaces? (stub :checks-for-draw {:return false})
-                                prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
+          (it "checks for a draw after each move until a win takes place"
+              (with-redefs [no-free-spaces? (stub :checks-for-draw {:return false})
+                            prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
 
-                    (with-in-str "3\n4\n9\n"
-                      (play-move [X O nil nil X O O X nil]
-                                 (players/configure-players player-options/human-human-id)))
+                (with-in-str "3\n4\n9\n"
+                  (play-move [X O nil nil X O O X nil]
+                             (players/configure-players player-options/human-human-id)))
 
-                    (should-have-invoked :checks-for-draw {:times 2})))
+                (should-have-invoked :checks-for-draw {:times 2})))
 
-              (it "announces win"
-                  (with-redefs [prompt/get-valid-next-move (stub :next-move {:return 3})
-                                prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
-                    (should-contain "The game was won by X"
-                                    (with-out-str (play-move [X O nil nil O nil X X O]
-                                                             (players/configure-players player-options/human-human-id))))))
+          (it "announces win"
+              (with-redefs [prompt/get-valid-next-move (stub :next-move {:return 3})
+                            prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
+                (should-contain "The game was won by X"
+                                (with-out-str (play-move [X O nil nil O nil X X O]
+                                                         (players/configure-players player-options/human-human-id))))))
 
-              (it "announces draw"
-                  (with-redefs [prompt/get-valid-next-move (stub :next-move {:return 2})
-                                prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
-                    (should-contain "The game was a draw"
-                                    (with-out-str (play-move [X O nil O X X O X O]
-                                                             (players/configure-players player-options/human-human-id) )))))
+          (it "announces draw"
+              (with-redefs [prompt/get-valid-next-move (stub :next-move {:return 2})
+                            prompt/get-replay-option (stub :valid-replay-option {:return "N"})]
+                (should-contain "The game was a draw"
+                                (with-out-str (play-move [X O nil O X X O X O]
+                                                         (players/configure-players player-options/human-human-id) )))))
 
-              (it "has players take turns until board is full"
-                  (should-contain "The game was a draw"
-                                  (with-in-str "1\n2\n3\n4\n5\n7\n6\n9\n8\nN\n"
-                                    (with-out-str
-                                      (play-move (empty-board)
-                                                 (players/configure-players player-options/human-human-id))))))
+          (it "has players take turns until board is full"
+              (should-contain "The game was a draw"
+                              (with-in-str "1\n2\n3\n4\n5\n7\n6\n9\n8\nN\n"
+                                (with-out-str
+                                  (play-move (empty-board)
+                                             (players/configure-players player-options/human-human-id))))))
 
-              (it "game can be played multiple times"
-                  (with-redefs [play-move (stub :play-move)
-                                empty-board (stub :initial-board {:return populated-board})
-                                get-players (stub :players {:return
-                                                            (players/configure-players player-options/human-human-id)
-                                                            })]
+          (it "game can be played multiple times"
+              (with-redefs [play-move (stub :play-move)
+                            empty-board (stub :initial-board {:return populated-board})
+                            get-players (stub :players {:return
+                                                        (players/configure-players player-options/human-human-id)
+                                                        })]
 
-                    (with-in-str "Y\nN\n"
-                      (with-out-str
-                        (play-game))))
-                  (should-have-invoked :play-move {:times 2}))))
+                (with-in-str "Y\nN\n"
+                  (with-out-str
+                    (play-game))))
+              (should-have-invoked :play-move {:times 2})))

--- a/tic-tac-toe/spec/tic_tac_toe/human_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/human_player_spec.clj
@@ -13,9 +13,4 @@
 
           (it "provides valid move through commandline prompt"
               (should-invoke prompt/get-valid-next-move {:times 1}
-                             (choose-move (empty-board))))
-
-          (it "displays the board when user enters move"
-              (should-invoke writer/display {:times 1}
-                             (with-in-str "2\n"
-                               (choose-move (empty-board))))))
+                             (choose-move (empty-board)))))

--- a/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/minimax_player_spec.clj
@@ -12,7 +12,6 @@
   (date-time/in-millis (date-time/interval starting-time finish-time)))
 
 (describe "Minimax Player"
-
           (it "takes winning move on top row"
               (should= 0
                        (choose-move [nil X X O O nil nil nil nil])))

--- a/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
@@ -4,16 +4,16 @@
 
 (describe "Player Options"
 
-          (it "has 5 categories"
-              (should= 7
+          (it "has 9 categories"
+              (should= 9
                        (count player-options)))
 
           (it "has display format"
-              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n (6) Random vs Random\n (7) Unbeatable vs Unbeatable\n "
+              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n (6) Random vs Unbeatable\n (7) Unbeatable vs Random\n (8) Random vs Random\n (9) Unbeatable vs Unbeatable\n "
                        (display)))
 
           (it "valid choices"
-              (should= '(1 2 3 4 5 6 7)
+              (should= '(1 2 3 4 5 6 7 8 9)
                        (valid-player-options)))
 
           (it "has an id for human vs human"
@@ -26,11 +26,20 @@
           (it "has an id for human vs random"
               (should= 3 human-random-id))
 
-         (it "has an id for unbeatable vs human"
-             (should= 4 unbeatable-human-id))
+          (it "has an id for unbeatable vs human"
+              (should= 4 unbeatable-human-id))
 
           (it "has an id for human vs unbeatable"
               (should= 5 human-unbeatable-id))
 
+          (it "has an id for random vs unbeatable"
+              (should= 6 random-unbeatable-id))
+
+          (it "has an id for unbeatable vs random"
+              (should= 7 unbeatable-random-id))
+
           (it "has an id for random vs random"
-              (should= 6 random-random-id)))
+              (should= 8 random-random-id))
+
+          (it "has an id for unbeatable vs unbeatable"
+              (should= 9 unbeatable-unbeatable-id)))

--- a/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
@@ -5,15 +5,15 @@
 (describe "Player Options"
 
           (it "has 5 categories"
-              (should= 5
+              (should= 6
                        (count player-options)))
 
           (it "has display format"
-              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n "
+              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n (6) Random vs Random\n "
                        (display)))
 
           (it "valid choices"
-              (should= '(1 2 3 4 5)
+              (should= '(1 2 3 4 5 6)
                        (valid-player-options)))
 
           (it "has an id for human vs human"
@@ -32,4 +32,5 @@
           (it "has an id for human vs unbeatable"
               (should= 5 human-unbeatable-id))
 
-          )
+          (it "has an id for random vs random"
+              (should= 6 random-random-id)))

--- a/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/player_options_spec.clj
@@ -5,15 +5,15 @@
 (describe "Player Options"
 
           (it "has 5 categories"
-              (should= 6
+              (should= 7
                        (count player-options)))
 
           (it "has display format"
-              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n (6) Random vs Random\n "
+              (should= "(1) Human vs Human\n (2) Random vs Human\n (3) Human vs Random\n (4) Unbeatable vs Human\n (5) Human vs Unbeatable\n (6) Random vs Random\n (7) Unbeatable vs Unbeatable\n "
                        (display)))
 
           (it "valid choices"
-              (should= '(1 2 3 4 5 6)
+              (should= '(1 2 3 4 5 6 7)
                        (valid-player-options)))
 
           (it "has an id for human vs human"

--- a/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
@@ -43,5 +43,11 @@
                 (should= human-player/choose-move
                          (get human-unbeatable X))
                 (should= minimax-player/choose-move
-                         (get human-unbeatable O)))))
+                         (get human-unbeatable O))))
 
+          (it "finds player configuration for random vs random"
+              (let [random-random (configure-players 6)]
+                (should= random-player/delayed-random-move
+                         (get random-random X))
+                (should= random-player/delayed-random-move
+                         (get random-random O)))))

--- a/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
@@ -45,15 +45,29 @@
                 (should= minimax-player/choose-move
                          (get human-unbeatable O))))
 
+          (it "finds player configuration for random vs unbeatable"
+              (let [random-unbeatable (configure-players 6)]
+                (should= random-player/delayed-random-move
+                         (get random-unbeatable X))
+                (should= minimax-player/delayed-unbeatable-move
+                         (get random-unbeatable O))))
+
+          (it "finds player configuration for unbeatable vs random"
+              (let [unbeatable-random (configure-players 7)]
+                (should= minimax-player/delayed-unbeatable-move
+                         (get unbeatable-random X))
+                (should= random-player/delayed-random-move
+                         (get unbeatable-random O))))
+
           (it "finds player configuration for random vs random"
-              (let [random-random (configure-players 6)]
+              (let [random-random (configure-players 8)]
                 (should= random-player/delayed-random-move
                          (get random-random X))
                 (should= random-player/delayed-random-move
                          (get random-random O))))
 
          (it "finds player configuration for unbeatable vs unbeatable"
-              (let [unbeatable-unbeatable (configure-players 7)]
+              (let [unbeatable-unbeatable (configure-players 9)]
                 (should= minimax-player/delayed-unbeatable-move
                          (get unbeatable-unbeatable X))
                 (should= minimax-player/delayed-unbeatable-move

--- a/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/players_spec.clj
@@ -50,4 +50,11 @@
                 (should= random-player/delayed-random-move
                          (get random-random X))
                 (should= random-player/delayed-random-move
-                         (get random-random O)))))
+                         (get random-random O))))
+
+         (it "finds player configuration for unbeatable vs unbeatable"
+              (let [unbeatable-unbeatable (configure-players 7)]
+                (should= minimax-player/delayed-unbeatable-move
+                         (get unbeatable-unbeatable X))
+                (should= minimax-player/delayed-unbeatable-move
+                         (get unbeatable-unbeatable O)))))

--- a/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
@@ -1,14 +1,16 @@
 (ns tic-tac-toe.random-player-spec
   (:require [speclj.core :refer :all]
             [tic-tac-toe.random-player :refer :all]
-            [tic-tac-toe.marks :refer :all]))
+            [tic-tac-toe.marks :refer :all]
+            [tic-tac-toe.board :as board]))
+
+(defn prove-execution[msg]
+  (print "Has executed from" msg))
 
 (describe "Random Player"
-
           (it "Chooses the only free space on the board"
               (should= 7
-                       (choose-move [X O X X X O O nil O])
-                       ))
+                       (choose-move [X O X X X O O nil O])))
 
           (it "Chooses a free space from a partially populated board"
               (should-contain (choose-move [X O nil nil nil X O nil X])
@@ -16,4 +18,15 @@
 
           (it "Chooses a free space on an empty board"
               (should-contain (choose-move (vec (repeat 9 nil)))
-                              (range 0 9))))
+                              (range 0 9)))
+
+          (it "Executes another function when making a delayed move"
+              (binding [sleep prove-execution]
+                (should= "Has executed from delayed-move test"
+                         (with-out-str
+                           (delayed-move "delayed-move test" [X O X X X O O nil O])))))
+
+          (it "Chooses valid move when delay mechanism is in place"
+              (binding [sleep (fn [nothing-happens] nothing-happens)]
+                (should= 7
+                         (delayed-move "delayed-move test" [X O X X X O O nil O])))))

--- a/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
@@ -2,11 +2,7 @@
   (:require [speclj.core :refer :all]
             [tic-tac-toe.random-player :refer :all]
             [tic-tac-toe.marks :refer :all]
-            [tic-tac-toe.board :as board]
-            [tic-tac-toe.delayed-player :as delayed-player]))
-
-(defn prove-execution[msg]
-  (print "Has executed from" msg))
+            [tic-tac-toe.board :as board]))
 
 (describe "Random Player"
           (it "Chooses the only free space on the board"

--- a/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
@@ -19,17 +19,4 @@
 
           (it "Chooses a free space on an empty board"
               (should-contain (choose-move (vec (repeat 9 nil)))
-                              (range 0 9)))
-
-          ;(it "Executes another function when making a delayed move"
-          ;    (binding [delayed-player/sleep prove-execution]
-          ;      (should= "Has executed from delayed-move test"
-          ;               (with-out-str
-          ;                 (delayed-move "delayed-move test" [X O X X X O O nil O])))))
-
-          ;(it "Chooses valid move when delay mechanism is in place"
-          ;    (binding [delayed-player/sleep (fn [nothing-happens] nothing-happens)]
-          ;      (should= 7
-;                         (delayed-move "delayed-move test" [X O X X X O O nil O])
-          )
-;)))
+                              (range 0 9))))

--- a/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/random_player_spec.clj
@@ -2,7 +2,8 @@
   (:require [speclj.core :refer :all]
             [tic-tac-toe.random-player :refer :all]
             [tic-tac-toe.marks :refer :all]
-            [tic-tac-toe.board :as board]))
+            [tic-tac-toe.board :as board]
+            [tic-tac-toe.delayed-player :as delayed-player]))
 
 (defn prove-execution[msg]
   (print "Has executed from" msg))
@@ -20,13 +21,15 @@
               (should-contain (choose-move (vec (repeat 9 nil)))
                               (range 0 9)))
 
-          (it "Executes another function when making a delayed move"
-              (binding [sleep prove-execution]
-                (should= "Has executed from delayed-move test"
-                         (with-out-str
-                           (delayed-move "delayed-move test" [X O X X X O O nil O])))))
+          ;(it "Executes another function when making a delayed move"
+          ;    (binding [delayed-player/sleep prove-execution]
+          ;      (should= "Has executed from delayed-move test"
+          ;               (with-out-str
+          ;                 (delayed-move "delayed-move test" [X O X X X O O nil O])))))
 
-          (it "Chooses valid move when delay mechanism is in place"
-              (binding [sleep (fn [nothing-happens] nothing-happens)]
-                (should= 7
-                         (delayed-move "delayed-move test" [X O X X X O O nil O])))))
+          ;(it "Chooses valid move when delay mechanism is in place"
+          ;    (binding [delayed-player/sleep (fn [nothing-happens] nothing-happens)]
+          ;      (should= 7
+;                         (delayed-move "delayed-move test" [X O X X X O O nil O])
+          )
+;)))

--- a/tic-tac-toe/spec/tic_tac_toe/validating_prompt_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/validating_prompt_spec.clj
@@ -63,7 +63,7 @@
               (should-invoke writer/invalid-player-option-message {:times 1}
                              (should-invoke writer/prompt-for-player-option {:times 2}
                                             (should= 1
-                                                     (with-in-str "6\n1\n"
+                                                     (with-in-str "66\n1\n"
                                                        (get-valid-player-option))))))
 
          (it "prompts and reads in replay option"

--- a/tic-tac-toe/spec/tic_tac_toe/writer_spec.clj
+++ b/tic-tac-toe/spec/tic_tac_toe/writer_spec.clj
@@ -4,6 +4,8 @@
             [tic-tac-toe.marks :refer :all]
             [tic-tac-toe.player-options :as player-options]))
 
+(def clear "\033[2J\033[;H\n")
+
 (describe "Command Line Writer"
           (around [it]
                   (with-out-str (it)))
@@ -29,16 +31,16 @@
                        (with-out-str(win-message "X"))))
 
           (it "displays empty board"
-              (should= "\n [ 1 ] [ 2 ] [ 3 ] \n [ 4 ] [ 5 ] [ 6 ] \n [ 7 ] [ 8 ] [ 9 ]\n"
-                       (with-out-str (display (vec (repeat 9 nil))))))
+              (should= (str clear "\n [ 1 ] [ 2 ] [ 3 ] \n [ 4 ] [ 5 ] [ 6 ] \n [ 7 ] [ 8 ] [ 9 ]\n"
+)                       (with-out-str (display (vec (repeat 9 nil))))))
 
           (it "displays board with occupied cells"
-              (should= "\n [ X ] [ 2 ] [ O ] \n [ 4 ] [ 5 ] [ X ] \n [ 7 ] [ 8 ] [ 9 ]\n"
+              (should= (str clear "\n [ X ] [ 2 ] [ O ] \n [ 4 ] [ 5 ] [ X ] \n [ 7 ] [ 8 ] [ 9 ]\n")
                        (with-out-str (display [X nil O nil nil X nil nil nil]))))
 
          (it "displays player options"
-            (should= (str "Choose player option:\n " (player-options/display) "\n")
-                    (with-out-str ( prompt-for-player-option))))
+            (should= (str clear "Choose player option:\n " (player-options/display) "\n")
+                    (with-out-str (prompt-for-player-option))))
 
          (it "displays invalid message when input is not a valid player option"
             (should= "Not a valid player option!\n"

--- a/tic-tac-toe/src/tic_tac_toe/delayed_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/delayed_player.clj
@@ -1,0 +1,8 @@
+(ns tic-tac-toe.delayed-player
+(:require [tic-tac-toe.board :as board]))
+
+(def ^:dynamic sleep #(Thread/sleep %))
+
+(defn delayed-move [interval player board]
+ (sleep interval)
+ (player board))

--- a/tic-tac-toe/src/tic_tac_toe/game.clj
+++ b/tic-tac-toe/src/tic_tac_toe/game.clj
@@ -45,6 +45,7 @@
 
 (defn play-move [board players]
   (loop [board board]
+    (writer/display board)
     (let [next-mark (mark-of-next-player board)
           updated-board (update-board-with-move players board next-mark)]
       (if (game-over? updated-board)

--- a/tic-tac-toe/src/tic_tac_toe/human_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/human_player.clj
@@ -3,5 +3,4 @@
             [tic-tac-toe.writer :as writer]))
 
   (defn choose-move [board]
-    (writer/display board)
     (prompt/get-valid-next-move board))

--- a/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/minimax_player.clj
@@ -1,7 +1,8 @@
 (ns tic-tac-toe.minimax-player
   (:require [tic-tac-toe.minimax-player :refer :all]
             [tic-tac-toe.board :as board]
-            [tic-tac-toe.marks :as marks]))
+            [tic-tac-toe.marks :as marks]
+            [tic-tac-toe.delayed-player :as delayed-player]))
 
 (def draw-score 0)
 (def max-score 10)
@@ -111,3 +112,6 @@
                                      initial-alpha
                                      initial-beta)]
     best-position))
+
+(def delayed-unbeatable-move
+  (partial delayed-player/delayed-move 1000 (partial choose-move)))

--- a/tic-tac-toe/src/tic_tac_toe/player_options.clj
+++ b/tic-tac-toe/src/tic_tac_toe/player_options.clj
@@ -5,6 +5,7 @@
 (def human-random-id 3)
 (def unbeatable-human-id 4)
 (def human-unbeatable-id 5)
+(def random-random-id 6)
 
 (def player-options
   { human-human-id "Human vs Human"
@@ -12,6 +13,7 @@
     human-random-id "Human vs Random"
     unbeatable-human-id "Unbeatable vs Human"
     human-unbeatable-id "Human vs Unbeatable"
+    random-random-id "Random vs Random"
    })
 
 (defn display[]

--- a/tic-tac-toe/src/tic_tac_toe/player_options.clj
+++ b/tic-tac-toe/src/tic_tac_toe/player_options.clj
@@ -6,6 +6,7 @@
 (def unbeatable-human-id 4)
 (def human-unbeatable-id 5)
 (def random-random-id 6)
+(def unbeatable-unbeatable-id 7)
 
 (def player-options
   { human-human-id "Human vs Human"
@@ -14,6 +15,7 @@
     unbeatable-human-id "Unbeatable vs Human"
     human-unbeatable-id "Human vs Unbeatable"
     random-random-id "Random vs Random"
+    unbeatable-unbeatable-id "Unbeatable vs Unbeatable"
    })
 
 (defn display[]

--- a/tic-tac-toe/src/tic_tac_toe/player_options.clj
+++ b/tic-tac-toe/src/tic_tac_toe/player_options.clj
@@ -5,18 +5,23 @@
 (def human-random-id 3)
 (def unbeatable-human-id 4)
 (def human-unbeatable-id 5)
-(def random-random-id 6)
-(def unbeatable-unbeatable-id 7)
+(def random-unbeatable-id 6)
+(def unbeatable-random-id 7)
+(def random-random-id 8)
+(def unbeatable-unbeatable-id 9)
 
 (def player-options
-  { human-human-id "Human vs Human"
+  (sorted-map
+    human-human-id "Human vs Human"
     random-human-id "Random vs Human"
     human-random-id "Human vs Random"
     unbeatable-human-id "Unbeatable vs Human"
     human-unbeatable-id "Human vs Unbeatable"
+    random-unbeatable-id "Random vs Unbeatable"
+    unbeatable-random-id "Unbeatable vs Random"
     random-random-id "Random vs Random"
     unbeatable-unbeatable-id "Unbeatable vs Unbeatable"
-   })
+   ))
 
 (defn display[]
   (apply str (map (fn[[k v]] (str "(" k ") " v "\n ")) player-options)))

--- a/tic-tac-toe/src/tic_tac_toe/players.clj
+++ b/tic-tac-toe/src/tic_tac_toe/players.clj
@@ -17,4 +17,4 @@
     (= game-option player-options/unbeatable-human-id) (setup-players minimax-player/choose-move human-player/choose-move)
     (= game-option player-options/human-unbeatable-id) (setup-players human-player/choose-move minimax-player/choose-move)
     (= game-option player-options/random-random-id) (setup-players random-player/delayed-random-move random-player/delayed-random-move )
-    ))
+    (= game-option player-options/unbeatable-unbeatable-id) (setup-players minimax-player/delayed-unbeatable-move minimax-player/delayed-unbeatable-move)))

--- a/tic-tac-toe/src/tic_tac_toe/players.clj
+++ b/tic-tac-toe/src/tic_tac_toe/players.clj
@@ -16,5 +16,5 @@
     (= game-option player-options/human-random-id) (setup-players human-player/choose-move random-player/choose-move)
     (= game-option player-options/unbeatable-human-id) (setup-players minimax-player/choose-move human-player/choose-move)
     (= game-option player-options/human-unbeatable-id) (setup-players human-player/choose-move minimax-player/choose-move)
-    )
-  )
+    (= game-option player-options/random-random-id) (setup-players random-player/delayed-random-move random-player/delayed-random-move )
+    ))

--- a/tic-tac-toe/src/tic_tac_toe/players.clj
+++ b/tic-tac-toe/src/tic_tac_toe/players.clj
@@ -6,7 +6,7 @@
             [tic-tac-toe.player-options :as player-options]))
 
 (defn- setup-players [first-player second-player]
- { X first-player
+  { X first-player
    O second-player})
 
 (defn configure-players [game-option]
@@ -16,5 +16,7 @@
     (= game-option player-options/human-random-id) (setup-players human-player/choose-move random-player/choose-move)
     (= game-option player-options/unbeatable-human-id) (setup-players minimax-player/choose-move human-player/choose-move)
     (= game-option player-options/human-unbeatable-id) (setup-players human-player/choose-move minimax-player/choose-move)
+    (= game-option player-options/random-unbeatable-id) (setup-players random-player/delayed-random-move minimax-player/delayed-unbeatable-move)
+    (= game-option player-options/unbeatable-random-id) (setup-players minimax-player/delayed-unbeatable-move random-player/delayed-random-move)
     (= game-option player-options/random-random-id) (setup-players random-player/delayed-random-move random-player/delayed-random-move )
     (= game-option player-options/unbeatable-unbeatable-id) (setup-players minimax-player/delayed-unbeatable-move minimax-player/delayed-unbeatable-move)))

--- a/tic-tac-toe/src/tic_tac_toe/random_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/random_player.clj
@@ -1,6 +1,14 @@
 (ns tic-tac-toe.random-player
- (:require [tic-tac-toe.board :as board]
-  ))
+ (:require [tic-tac-toe.board :as board]))
+
+(def ^:dynamic sleep #(Thread/sleep %))
 
 (defn choose-move [board]
-  (rand-nth (board/indicies-of-free-spaces board)))
+   (rand-nth (board/indicies-of-free-spaces board)))
+
+(defn delayed-move [interval board]
+ (sleep interval)
+ (choose-move board))
+
+(def delayed-random-move
+  (partial delayed-move 1000))

--- a/tic-tac-toe/src/tic_tac_toe/random_player.clj
+++ b/tic-tac-toe/src/tic_tac_toe/random_player.clj
@@ -1,14 +1,9 @@
 (ns tic-tac-toe.random-player
- (:require [tic-tac-toe.board :as board]))
-
-(def ^:dynamic sleep #(Thread/sleep %))
+ (:require [tic-tac-toe.board :as board]
+           [tic-tac-toe.delayed-player :as delayed-player]))
 
 (defn choose-move [board]
    (rand-nth (board/indicies-of-free-spaces board)))
 
-(defn delayed-move [interval board]
- (sleep interval)
- (choose-move board))
-
 (def delayed-random-move
-  (partial delayed-move 1000))
+  (partial delayed-player/delayed-move 1000 (partial choose-move)))

--- a/tic-tac-toe/src/tic_tac_toe/writer.clj
+++ b/tic-tac-toe/src/tic_tac_toe/writer.clj
@@ -24,6 +24,9 @@
     (map (fn[[cell-one cell-two cell-three]]
            (str "\n [ " cell-one " ] [ " cell-two " ] [ " cell-three " ]")) board)))
 
+(defn- clear []
+   (println "\033[2J\033[;H"))
+
 (defn prompt-for-next-move []
   (println "Please enter your next move"))
 
@@ -40,16 +43,18 @@
   (println "The game was won by" player-symbol))
 
 (defn display [board]
+  (clear)
   (apply println (border (board/get-rows (vec (board-with-one-based-indicies board))))))
 
  (defn prompt-for-player-option []
+   (clear)
    (println "Choose player option:\n" (player-options/display)))
 
 (defn invalid-player-option-message[]
   (println "Not a valid player option!"))
 
 (defn prompt-for-replay []
-     (println (str "Play again? (" replay-option/replay-option " to replay)")))
+  (println (str "Play again? (" replay-option/replay-option " to replay)")))
 
 (defn goodbye-msg []
   (println "Thanks for playing. Goodbye!"))


### PR DESCRIPTION
@jsuchy @ecomba @dirv  - This pull request adds the functionality to play combinations of automated computer players. I've blogged the different ideas I had regarding creating a delayed player [here](http://gemcfadyen.github.io/georginam.com/apprenticeship/2016/04/07/apprenticeship-day-123.html)

The changes are as follows:
- Options for the following games added to the menu - random vs random, unbeatable vs unbeatable, random vs unbeatable and unbeatable vs random.
- In the game module, the board is displayed with each move, giving every intermediate state of the board.
- Removed the display board invocation from human-player as now the game module is responsible for displaying the board
- console is cleared after each move thus hiding the intermediate states from the player watching, improving user experience.
- Delayed player module introduces which allows a delay of one second before the player actually provides it's move
- player options changed to a sorted map as the usual map is not order specific and was changing.
